### PR TITLE
Added viewSurvey.html with survey management features

### DIFF
--- a/src/main/resources/templates/viewSurvey.html
+++ b/src/main/resources/templates/viewSurvey.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>View Surveys</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<div class="container mt-5">
+  <h2>Survey Dashboard</h2>
+
+  <!-- Display message if no surveys are available -->
+  <div th:if="${#lists.isEmpty(surveys)}" class="alert alert-info">
+    No surveys found. Please create a new survey!
+  </div>
+
+  <!-- List of surveys -->
+  <div th:each="survey : ${surveys}" class="card mb-3">
+    <div class="card-body">
+      <h5 class="card-title" th:text="${survey.surveyName}">Survey Name</h5>
+      <p class="card-text">
+        <small class="text-muted" th:text="'Questions: ' + ${survey.surveyQuestions.size()}">
+          Questions: 0
+        </small>
+      </p>
+      <span class="badge"
+            th:classappend="${survey.isOpen ? 'bg-success' : 'bg-danger'}"
+            th:text="${survey.isOpen ? 'Open' : 'Closed'}">Status</span>
+
+      <!-- Action buttons -->
+      <div class="btn-group mt-3">
+        <a th:href="@{'/api/surveys/' + ${survey.surveyId}}" class="btn btn-outline-primary">Access</a>
+        <a th:href="@{'/api/surveys/' + ${survey.surveyId} + '/answer'}"
+           th:if="${survey.isOpen}" class="btn btn-outline-success">Answer</a>
+        <button type="button" class="btn btn-outline-secondary"
+                th:onclick="'toggleSurveyStatus(' + ${survey.surveyId} + ')'"
+                th:text="${survey.isOpen ? 'Close' : 'Open'}">
+          Toggle Status
+        </button>
+        <button type="button" class="btn btn-outline-info"
+                th:onclick="'generateResponses(' + ${survey.surveyId} + ')'">
+          Generate Responses
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+  // JavaScript functions for toggling status and generating responses
+  async function toggleSurveyStatus(surveyId) {
+    try {
+      const response = await fetch(`/api/surveys/${surveyId}/toggle`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      });
+
+      if (response.ok) {
+        alert('Survey status updated successfully!');
+        window.location.reload();
+      } else {
+        alert('Failed to update survey status');
+      }
+    } catch (error) {
+      console.error('Error:', error);
+      alert('Error updating survey status');
+    }
+  }
+
+  async function generateResponses(surveyId) {
+    try {
+      const response = await fetch(`/api/surveys/${surveyId}/responses`, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      });
+
+      if (response.ok) {
+        const data = await response.json();
+        alert('Responses generated successfully!');
+        console.log(data);
+      } else {
+        alert('Failed to generate responses');
+      }
+    } catch (error) {
+      console.error('Error:', error);
+      alert('Error generating responses');
+    }
+  }
+</script>
+</body>
+</html>


### PR DESCRIPTION
This Pull Request implements the viewSurvey.html page for managing and interacting with surveys. The new page includes the following features:

Lists all available surveys with their name, number of questions, and current status (Open/Closed).
Provides action buttons to:
Access individual surveys.
Toggle the status of surveys (Open/Close).
Generate responses for surveys.
Answer surveys if they are currently open.
Utilizes Thymeleaf for server-side rendering and Bootstrap for responsive design.
Includes JavaScript functions for handling status toggling and response generation via AJAX requests.
This update enhances the user experience by providing an intuitive interface for managing surveys.